### PR TITLE
Adjust default assets prefix for lazy engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,21 @@ var merge = require("broccoli-merge-trees");
 var path = require("path");
 
 function getDefaultAssetHttpPrefix(parent) {
-  if (parent && parent.lazyLoading) {
-    return '/engines-dist/' + parent.name + '/assets';
+  // the default http prefix differs between Ember app and lazy Ember engine
+  // iterate over the parent's chain and look for a lazy engine or there are
+  // no more parents, which means we've reached the Ember app project
+  var current = parent;
+
+  while(current.parent) {
+    if (current.lazyLoading === true && current.useDeprecatedIncorrectCSSProcessing !== true) {
+      // only lazy engines with disabled deprecated CSS processing will inline their assets in
+      // the engines-dist folder
+      return '/engines-dist/' + current.name + '/assets';
+    }
+    current = current.parent;
   }
+
+  // at this point, the highlevel container is Ember app and we should use the default "assets" prefix
   return 'assets';
 }
 


### PR DESCRIPTION
The existing logic for determining the assets prefix for lazy engines doesn't account for lazy engines, which are not immediate parents of the ember-cli-eyeglass. The PR makes a small adjustment to walk the whole ancestor tree for a lazy engine and also adjust for the newly introduced deprecated CSS processing flag for lazy engines, which are still hoisting their CSS to application level.